### PR TITLE
Add new option "Path Skip"

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,11 @@
 					"default": "0",
 					"description": "Number of folders which should be used for include guard. Disabled with 0."
 				},
+				"C/C++ Include Guard.Path Skip": {
+					"type": "number",
+					"default": "0",
+					"description": "Number of folders below the workspace root that should be skipped for include guard. Disabled with 0."
+				},
 				"C/C++ Include Guard.Remove Pragma Once": {
 					"type": "boolean",
 					"default": "true",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -65,17 +65,13 @@ function fromFileName(
     fileName = fileName.substr(baseUri.uri.toString().length + 1);
 
     if (pathDepth > 0) {
-      let index: number;
-      let count = 0;
-      for (index = fileName.length - 1; index >= 0; --index) {
-        if (fileName.charAt(index) === "/") {
-          count++;
-          if (count === pathDepth + 1) {
-            fileName = fileName.substr(index + 1);
-            break;
-          }
-        }
-      }
+      const folderSep = "/";
+      let pathSegments = fileName.split(folderSep);
+
+      // Keep only the last pathDepth folders and the file segment
+      pathSegments = pathSegments.slice(-(pathDepth + 1));
+
+      fileName = pathSegments.join(folderSep);
     }
   } else {
     fileName = path.basename(fileName);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -46,6 +46,7 @@ function fromGUID(preventDecimal: boolean): string {
 function fromFileName(
   fullPath: boolean,
   pathDepth: number,
+  pathSkip: number,
   shortenUnderscores: boolean,
   removeExtension: boolean
 ): string {
@@ -62,11 +63,15 @@ function fromFileName(
 
   let fileName = documentUri.toString();
   if (fullPath && baseUri !== undefined) {
+    // Convert to path relative to baseUri
     fileName = fileName.substr(baseUri.uri.toString().length + 1);
 
     if (pathDepth > 0) {
       const folderSep = "/";
       let pathSegments = fileName.split(folderSep);
+
+      // Discard the first pathSkip segments (but always keep at least one!)
+      pathSegments = pathSegments.slice(Math.min(pathSkip, pathSegments.length - 1));
 
       // Keep only the last pathDepth folders and the file segment
       pathSegments = pathSegments.slice(-(pathDepth + 1));
@@ -105,12 +110,14 @@ function createDirectives(): Array<string> {
   const removeExtension = config.get<boolean>("Remove Extension", false);
   const commentStyle = config.get<string>("Comment Style", "Block");
   const pathDepth = config.get<number>("Path Depth", 0);
+  const pathSkip = config.get<number>("Path Skip", 0);
 
   let macroName: string;
   if (macroType === "Filename") {
     macroName = fromFileName(
       false,
       pathDepth,
+      pathSkip,
       shortenUnderscores,
       removeExtension
     );
@@ -118,6 +125,7 @@ function createDirectives(): Array<string> {
     macroName = fromFileName(
       true,
       pathDepth,
+      pathSkip,
       shortenUnderscores,
       removeExtension
     );


### PR DESCRIPTION
This pull request introduces a new configuration option: _Path Skip_.

# What's the problem? (aka _Why would anyone want this?_)
I have a situation where my workspace root contains several independent projects, e.g.:
```
workspaceRoot/
├── app/
│   ├── one/
│   └── two/
└── lib/
    ├── bar/
    └── foo/
```

I want my (filepath-based) include guards to **not** include the prefix for `app` or `lib`.
The problem with the current version of this extension is that I cannot do this if my include files are not all on the same hierarchy level, e.g.:
- for `app/one/x/a.h` I want `X_A` as include guard, so I would have to configure a path depth of 1.
- for `app/one/x/y/b.h` I want `X_Y_B` as include guard. But with path depth set to 1, I get `Y_B` ⚡️

# How does this pull request solve the problem?
It introduces a new configuration option _Path Skip_ which can be set to a numeric value _n_.
For filepath-based include guard generation the _n_ uppermost folders below the workspace root are neglected for include guard generation.
The problem above can be solved by setting path skip to 2.