### PR TITLE
Feature: Folder-specific prefixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,8 +101,31 @@
 				"C/C++ Include Guard.Prefix": {
 					"type": "string",
 					"default": "",
-					"description": "Prefix added to include guard macros.",
+					"description": "Prefix added to include guard macros. Prefix will be concatenated to the beginning of the subfolder prefix.",
 					"scope": "resource"
+				},
+				"C/C++ Include Guard.Subfolder Prefixes": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"folderPath": {
+								"type": "string",
+								"description": "Folder path relative to the workspace root."
+							},
+							"prefix": {
+								"type": "string",
+								"description": "Prefix added to include guard macros."
+							}
+						},
+						"required": [
+							"folderPath",
+							"prefix"
+						],
+						"additionalProperties": false
+					},
+					"default": [],
+					"description": "Prefix added to include guard macros when file is in a subfolder of the workspace root."
 				},
 				"C/C++ Include Guard.Suffix": {
 					"type": "string",

--- a/src/SubfolderPrefixDef.ts
+++ b/src/SubfolderPrefixDef.ts
@@ -1,0 +1,22 @@
+/**
+ * Interface for the "Prefix for Subfolder" setting. Setting
+ * is an array of SubfolderPrefixDef objects.
+ */
+interface SubfolderPrefixDef {
+  /**
+   * The prefix for the subfolder.
+   * @type {string}
+   * @memberof SubfolderPrefixDef
+   * @description The path of the subfolder relative to the workspace root.
+   */
+  folderPath: string;
+  /**
+   * The prefix for the subfolder.
+   * @type {string}
+   * @memberof SubfolderPrefixDef
+   * @description The prefix used when the file is in the subfolder.
+   */
+  prefix: string;
+};
+
+export { SubfolderPrefixDef };


### PR DESCRIPTION
I have a case where my project has multiple "subprojects" in the root folder, without using the multi-root workspace feature of VSCode. Something like this:

- `ff-core/include/ff-core`
- `ff-core/tests/include/ff-core-tests`
- `ff-desktop/include/ff-core`
- etc.

Each folder has its own include guard prefix. The prefix is expanded on the folder name, so using the "path skip" isn't sufficient for my use-case.

This PR adds the ability to specify prefixes if the file is in a specified folder, relative to the workspace root. This is in addition to the existing "Prefix" option (so existing users of the extension do not have to modify their configuration), which prepends to the subfolder prefixes.