### PR TITLE
Feature: Add whitelist/blacklist to auto include/update

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,15 +45,15 @@
 					"markdownDescription": "Automatically update the include guard when renaming a file (only have effect when macro type is `Filename` or `Filepath`",
 					"scope": "resource"
 				},
-				"C/C++ Include Guard.Auto Update Path Whitelist": {
+				"C/C++ Include Guard.Auto Update Path Allowlist": {
 					"type": "array",
 					"items": {
 						"type": "string"
 					},
-					"description": "A list of path roots that will be automatically updated when `C/C++ Include Guard.Auto Update Include Guard` is enabled. Empty will include all paths by default.",
+					"description": "A list of path roots that will be automatically updated when `C/C++ Include Guard.Auto Update Include Guard` is enabled. If empty, all paths are included by default.",
 					"scope": "resource"
 				},
-				"C/C++ Include Guard.Auto Update Path Blacklist": {
+				"C/C++ Include Guard.Auto Update Path Blocklist": {
 					"type": "array",
 					"items": {
 						"type": "string"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,22 @@
 					"markdownDescription": "Automatically update the include guard when renaming a file (only have effect when macro type is `Filename` or `Filepath`",
 					"scope": "resource"
 				},
+				"C/C++ Include Guard.Auto Update Path Whitelist": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"description": "A list of path roots that will be automatically updated when `C/C++ Include Guard.Auto Update Include Guard` is enabled. Empty will include all paths by default.",
+					"scope": "resource"
+				},
+				"C/C++ Include Guard.Auto Update Path Blacklist": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"description": "A list of path roots that will not be automatically updated when `C/C++ Include Guard.Auto Update Include Guard` is enabled.",
+					"scope": "resource"
+				},
 				"C/C++ Include Guard.Header Extensions": {
 					"type": "array",
 					"items": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,23 +56,23 @@ function shouldUpdateGuard(file: vscode.Uri)
 function shouldAutoIncludeGuardInFile(file: vscode.Uri): boolean {
     const baseUri = vscode.workspace.getWorkspaceFolder(file);
     if (baseUri === undefined) {
-        // Whitelist and blacklist are relative to workspace root. If workspace uri is not found,
+        // Allowlist and blocklist are relative to workspace root. If workspace uri is not found,
         // assume we shouldn't auto update include guard.
         return false;
     }
 
-    const whitelist: string[] = getConfig(file).get<string[]>("Auto Update Path Whitelist", []);
-    const blacklist: string[] = getConfig(file).get<string[]>("Auto Update Path Blacklist", []);
+    const allowlist: string[] = getConfig(file).get<string[]>("Auto Update Path Allowlist", []);
+    const blocklist: string[] = getConfig(file).get<string[]>("Auto Update Path Blocklist", []);
 
-    // If the whitelist is empty, assume all files are included in the whitelist.
-    // Whitelist and blacklist are relative to the workspace root. Need to
+    // If the allowlist is empty, assume all files are included in the allowlist.
+    // Allowlist and blocklist are relative to the workspace root. Need to
     // take workspace root into account, since the workspace root is not
-    // included in the whitelist and blacklist paths.
+    // included in the allowlist and blocklist paths.
     const relativePath = file.toString().substring(baseUri.uri.toString().length + 1);
-    if (whitelist.length === 0 || whitelist.some(path => relativePath.startsWith(path))) {
-        // If the file is in the whitelist, or the whitelist is empty,
-        // check if the file is in the blacklist.
-        if(!blacklist.some(path => relativePath.startsWith(path))) {
+    if (allowlist.length === 0 || allowlist.some(path => relativePath.startsWith(path))) {
+        // If the file is in the allowlist, or the allowlist is empty,
+        // check if the file is in the blocklist.
+        if(!blocklist.some(path => relativePath.startsWith(path))) {
             return true;
         }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,12 +33,50 @@ function isOpenedInEditor(file: vscode.Uri) : boolean
  */
 function shouldUpdateGuard(file: vscode.Uri)
 {
-    if (getConfig(file).get<boolean>("Auto Update Include Guard"))
+    if (!getConfig(file).get<boolean>("Auto Update Include Guard"))
     {
-        const macroType = getConfig(file).get<string>("Macro Type", "GUID");
-        if (macroType === "Filename" || macroType === "Filepath") //only effective when the macro type is either "Filename" or "Filepath"
-            return true;
+        return false;
     }
+
+    const macroType = getConfig(file).get<string>("Macro Type", "GUID");
+    if (macroType === "Filename" || macroType === "Filepath") { //only effective when the macro type is either "Filename" or "Filepath"
+        if(shouldAutoIncludeGuardInFile(file)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Determine whether the include guard should be automatically included.
+ * @param file Uri of the file
+ * @return true if the include guard should be automatically included, false otherwise
+ */
+function shouldAutoIncludeGuardInFile(file: vscode.Uri): boolean {
+    const baseUri = vscode.workspace.getWorkspaceFolder(file);
+    if (baseUri === undefined) {
+        // Whitelist and blacklist are relative to workspace root. If workspace uri is not found,
+        // assume we shouldn't auto update include guard.
+        return false;
+    }
+
+    const whitelist: string[] = getConfig(file).get<string[]>("Auto Update Path Whitelist", []);
+    const blacklist: string[] = getConfig(file).get<string[]>("Auto Update Path Blacklist", []);
+
+    // If the whitelist is empty, assume all files are included in the whitelist.
+    // Whitelist and blacklist are relative to the workspace root. Need to
+    // take workspace root into account, since the workspace root is not
+    // included in the whitelist and blacklist paths.
+    const relativePath = file.toString().substring(baseUri.uri.toString().length + 1);
+    if (whitelist.length === 0 || whitelist.some(path => relativePath.startsWith(path))) {
+        // If the file is in the whitelist, or the whitelist is empty,
+        // check if the file is in the blacklist.
+        if(!blacklist.some(path => relativePath.startsWith(path))) {
+            return true;
+        }
+    }
+
     return false;
 }
 
@@ -62,9 +100,9 @@ export function activate(context: vscode.ExtensionContext) {
         {
             for (const newFile of event.files)
             {
-                if (getConfig(newFile).get<boolean>("Auto Include Guard Insertion For New File"))
-                {
-                    if (isHeader(newFile))
+                if(getConfig(newFile).get<boolean>("Auto Include Guard Insertion For New File", true)) {
+                    if (shouldAutoIncludeGuardInFile(newFile)
+                        && isHeader(newFile))
                     {
                         vscode.workspace.openTextDocument(newFile).then(doc =>
                             vscode.window.showTextDocument(doc).then(commands.insertIncludeGuard)
@@ -79,14 +117,14 @@ export function activate(context: vscode.ExtensionContext) {
     //This event will fire when moving the file & renaming the file
     vscode.workspace.onDidRenameFiles(event =>
     {
-            for (const renamedFile of event.files)
+        for (const renamedFile of event.files)
+        {
+            if (shouldUpdateGuard(renamedFile.newUri))
             {
-                if (shouldUpdateGuard(renamedFile.newUri))
-                {
-                    if (isHeader(renamedFile.newUri) && isOpenedInEditor(renamedFile.newUri))
-                        commands.updateIncludeGuard(); //Do insert include guard when there is none found, because user explicitly rename the file
-                }
+                if (isHeader(renamedFile.newUri) && isOpenedInEditor(renamedFile.newUri))
+                    commands.updateIncludeGuard(); //Do insert include guard when there is none found, because user explicitly rename the file
             }
+        }
     });
     //When the file is not currently shown in text editor, it should be automatically updated when it is opened
     vscode.workspace.onDidOpenTextDocument(async document =>


### PR DESCRIPTION
In my projects, I have some folders that I do want the auto-include feature, and others that I don't want the auto-include feature. This PR adds a whitelist/blacklist to better control which files should have an include guard auto-included.

If the whitelist is empty, all paths are considered in the whitelist. This makes it compatible with existing configurations.