### PR TITLE
Feature: Add option to convert path from camelCase/PascalCase to snake_case

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,12 @@
 					"description": "Source of include guard macros. GUID, Filename or File Path.",
 					"scope": "resource"
 				},
+				"C/C++ Include Guard.File Path Pascal Case to Snake Case": {
+					"type": "boolean",
+					"default": false,
+					"description": "Converts camelCase/PascalCase directores/filenames to snake_case.",
+					"scope": "resource"
+				},
 				"C/C++ Include Guard.Path Depth": {
 					"type": "number",
 					"default": "0",


### PR DESCRIPTION
In my projects, my file names are PascalCase, while in my include guard macro I write the filename in snake_case. This PR adds support for this to the extension (I currently have to edit the macro every time to add the underscore between words).

Disabled by default to not break existing configurations.