### PR TITLE
Adds an option to specify the string used to separate paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,11 @@
 					"description": "Number of folders which should be used for include guard. Disabled with 0.",
 					"scope": "resource"
 				},
+				"C/C++ Include Guard.Path Separator": {
+					"type": "string",
+					"default": "_",
+					"description": "String to replace path separators with when using Filepath Macro Type."
+				},
 				"C/C++ Include Guard.Path Skip": {
 					"type": "number",
 					"default": "0",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -49,6 +49,7 @@ function fromGUID(preventDecimal: boolean): string {
 function fromFileName(
   fullPath: boolean,
   pathDepth: number,
+  pathSeparator: string,
   pathSkip: number,
   shortenUnderscores: boolean,
   removeExtension: boolean,
@@ -100,7 +101,9 @@ function fromFileName(
     fileName = fileName.substring(0, fileName.length - extension.length);
   }
 
-  let macro = fileName.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+  let macro = fileName.toUpperCase()
+                  .replace(/\//g, pathSeparator)
+                  .replace(/[^A-Z0-9]/g, "_");
   if (shortenUnderscores) {
     macro = macro.replace(/_+/g, "_");
   }
@@ -162,6 +165,7 @@ function createDirectives(fileUri: vscode.Uri): Array<string> {
   const removeExtension = config.get<boolean>("Remove Extension", false);
   const commentStyle = config.get<string>("Comment Style", "Block");
   const pathDepth = config.get<number>("Path Depth", 0);
+  const pathSeparator = config.get<string>("Path Separator", "_");
   const pathSkip = config.get<number>("Path Skip", 0);
   const spacesAfterEndif = config.get<number>("Spaces After Endif", 1);
   const convertPathToSnakeCase = config.get<boolean>("File Path Pascal Case to Snake Case", false);
@@ -171,6 +175,7 @@ function createDirectives(fileUri: vscode.Uri): Array<string> {
     macroName = fromFileName(
       (macroType === "Filepath"),
       pathDepth,
+      pathSeparator,
       pathSkip,
       shortenUnderscores,
       removeExtension,


### PR DESCRIPTION
This lets you specify a different string to use with the Filepath mode. Specifically I wanted to use 2 underscores between path segments. Specifically I wanted to generate guards like this.

`PREFIX__FOLDER_1__FOLDER_2__HEADER_FILE_H__`