### PR TITLE
Ignore File if Pragma Once Detected

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,10 +115,16 @@
                     "default": "0",
                     "description": "Number of folders below the workspace root that should be skipped for include guard. Disabled with 0."
                 },
+                "C/C++ Include Guard.Ignore if Pragma Once": {
+                    "type": "boolean",
+                    "default": "false",
+                    "description": "Ignore file if #pragma once directive detected. Does not apply to update command.",
+                    "scope": "resource"
+                },
                 "C/C++ Include Guard.Remove Pragma Once": {
                     "type": "boolean",
                     "default": "true",
-                    "description": "Removes #pragma once directive if detected",
+                    "description": "Removes #pragma once directive if detected.",
                     "scope": "resource"
                 },
                 "C/C++ Include Guard.Prevent Decimal": {


### PR DESCRIPTION
Added "Ignore File if Pragma Once Detected" option.

This will ignore the file if #pragma once is found in the file, so include guards will not be inserted. The implementation does not apply the option to the update command.

When adding preexisting code that uses #pragma once, I do not want the extension to update the file.