### PR TITLE
avoid illegal names

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -206,6 +206,7 @@ function createDirectives(fileUri: vscode.Uri): Array<string> {
   );
 
   macroName = macroPrefix + macroSubfolderPrefix + macroName + macroSuffix;
+  macroName = macroName.replace(/^E/, "E_");
   const spaces = " ".repeat(spacesAfterEndif);
 
   let endifLine = "#endif";


### PR DESCRIPTION
Macro names beginning with `E` followed by a digit or an uppercase letter are reserved.